### PR TITLE
ENH/54 Refactor internal implementation of status codes

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -9,18 +9,114 @@ extern "C" {
 /* -------------------------- Macros -------------------------- */
 /* ------------------------------------------------------------ */
 
-/** Likely branch prediction */
-#define LIKELY(X)   __builtin_expect(!!(X), 1)
-/** Unlikely branch prediction */
+/**
+ * Likely branch prediction
+ */
+#define LIKELY(X) __builtin_expect(!!(X), 1)
+
+/**
+ * Unlikely branch prediction
+ */
 #define UNLIKELY(X) __builtin_expect(!!(X), 0)
 
-/** Return an error if a value is not valid */
+/**
+ * Return an error if a value is not valid
+ */
 #define ERROR_IF_EQ(ACT, EXP, RET) do { if (UNLIKELY((EXP) == (ACT))) return (RET); } while (0)
-/** Return a value if it differs from expected one */
+
+/**
+ * Return a value if it differs from expected one
+ */
 #define ERROR_IF_NEQ(ACT, EXP) do { if (UNLIKELY((EXP) != (ACT))) return (ACT); } while (0)
 
-/** Calculate size of an array */
+/**
+ * Calculate size of an array
+ */
 #define SIZE_ARRAY(ARR) (sizeof((ARR)) / sizeof((ARR)[0]))
+
+/**
+ * Mask for sequential number bits in status code
+ */
+#define STATUS_SEQ_MASK 0xFF
+
+/**
+ * Position of sequential number bits in status code
+ */
+#define STATUS_SEQ_POS 0
+
+/**
+ * Mask for severity bits in status code
+ */
+#define STATUS_SEVERITY_MASK 0x0F
+
+/**
+ * Position of severity bits in status code
+ */
+#define STATUS_SEVERITY_POS 8
+
+/**
+ * Mask for scope bits in status code
+ */
+#define STATUS_SCOPE_MASK 0xFFFF
+
+/**
+ * Position of scope bits in status code
+ */
+#define STATUS_SCOPE_POS 12
+
+/**
+ * Macro to create status code. It assumes that SCOPE_MAGIC macro is set.
+ * Up to 255 distinct codes may be created under the same scope.
+ */
+#define MAKE_STATUS(SEQ, SEVERITY) \
+    (((SCOPE_MAGIC) & STATUS_SCOPE_MASK) << STATUS_SCOPE_POS) | \
+    (((SEVERITY) & STATUS_SEVERITY_MASK) << STATUS_SEVERITY_POS) | \
+    (((SEQ) & STATUS_SEQ_MASK) << STATUS_SEQ_POS)
+
+/* ------------------------------------------------------------ */
+/* ------------------------ Data types ------------------------ */
+/* ------------------------------------------------------------ */
+
+/**
+ * Severities of status code
+ */
+typedef enum status_severity_
+{
+    /**<
+     * Special value to represent no severity (e.g. 'ok' status code)
+     */
+    status_severity_none = 0x00,
+    /**<
+     * Fatal error that needs attention immediately.
+     * Lefts the system in broken or not logically consistent state when unhandled
+    */
+    status_severity_fatal = 0x0E,
+    /**<
+     * Critical error that shall not occur in normal procedure.
+     * Does not make the system broken
+     */
+    status_severity_critical = 0x0C,
+    /**<
+     * Non-critical error.
+     * May occur in normal procedure
+     */
+    status_severity_non_critical = 0x0A
+} status_severity;
+
+/* ------------------------------------------------------------ */
+/* --------------------- Public functions --------------------- */
+/* ------------------------------------------------------------ */
+
+/**
+ * Check if a status code is fatal, hence shall be handled urgently.
+ *
+ * @param status Status to be checked.
+ * @return True if the status is fatal, false otherwise.
+ */
+static inline bool status_fatal(u32 status)
+{
+    return (status_severity_fatal == ((status >> STATUS_SEVERITY_POS) & STATUS_SEVERITY_MASK));
+}
 
 #ifdef __cplusplus
 }

--- a/include/mfrc522_drv.h
+++ b/include/mfrc522_drv.h
@@ -16,6 +16,14 @@ extern "C" {
 /* ------------------------------------------------------------ */
 
 /**
+ * Magic number regarded as an unique scope number that identifies this module
+ */
+#ifdef SCOPE_MAGIC
+#undef SCOPE_MAGIC
+#endif
+#define SCOPE_MAGIC 0xC0B0
+
+/**
  * Infinity flag recognized by 'mfrc522_drv_read_until_conf'
  */
 #define MFRC522_DRV_RETRY_CNT_INF 0xFFFFFFFF
@@ -54,30 +62,70 @@ extern "C" {
  */
 typedef enum mfrc522_drv_status_
 {
-    mfrc522_drv_status_ok = 0, /**< Success */
-    mfrc522_drv_status_nok, /**< Generic error code */
-    mfrc522_drv_status_nullptr, /**< Unexpected NULL pointer */
-    mfrc522_drv_status_ll_err, /**< An error occurred during low-level call */
-    mfrc522_drv_status_self_test_err, /**< Mismatch between expected and actual FIFO output during device self-test */
-
-    /* Device errors */
-    mfrc522_drv_status_dev_err, /**< Device not found */
-    mfrc522_drv_status_dev_rtr_err, /**< Maximum number of read retries reached */
-
-    /* Timer related */
-    mfrc522_drv_status_tim_prd_err, /**< Given timer period is too long */
-
-    /* TX/RX */
-    mfrc522_drv_status_transceive_timeout, /**< Timeout during transceive command */
-    mfrc522_drv_status_transceive_err, /**< At least one error present after transceive command */
-    mfrc522_drv_status_transceive_rx_mism, /**< A mismatch between expected and actual RX data size */
-
-    /* PICC related */
-    mfrc522_drv_status_picc_vrf_err, /**< Unknown ATQA returned after REQA command */
-    mfrc522_drv_status_anticoll_chksum_err, /**< Checksum error during anticollision */
-    mfrc522_drv_status_crc_err, /**< Computed CRC does not match up with expected one */
-    mfrc522_drv_status_crypto_err, /**< Invalid state of the crypto unit */
-    mfrc522_drv_status_halt_err /**< An error when halting a PICC */
+    /**<
+     * Status code returned when operation succeeded
+     */
+    mfrc522_drv_status_ok = MAKE_STATUS(0x00, status_severity_none),
+    /**<
+     * Generic status regarded as non-critical error
+     */
+    mfrc522_drv_status_nok = MAKE_STATUS(0x01, status_severity_non_critical),
+    /**<
+     * Unexpected NULL pointer
+     */
+    mfrc522_drv_status_nullptr = MAKE_STATUS(0x02, status_severity_fatal),
+    /**<
+     * An error occurred during low-level call.
+     */
+    mfrc522_drv_status_ll_err = MAKE_STATUS(0x03, status_severity_fatal),
+    /**<
+     * Mismatch between expected and actual FIFO output during device self-test
+     */
+    mfrc522_drv_status_self_test_err = MAKE_STATUS(0x04, status_severity_critical),
+    /**<
+     * Device not found
+     */
+    mfrc522_drv_status_dev_err = MAKE_STATUS(0x05, status_severity_critical),
+    /**
+     * Maximum number of read retries reached
+     */
+    mfrc522_drv_status_dev_rtr_err = MAKE_STATUS(0x06, status_severity_critical),
+    /**<
+     * Given timer period is too long
+     */
+    mfrc522_drv_status_tim_prd_err = MAKE_STATUS(0x07, status_severity_non_critical),
+    /**<
+     * Timeout during transceive command
+     */
+    mfrc522_drv_status_transceive_timeout = MAKE_STATUS(0x08, status_severity_critical),
+    /**<
+     * At least one error present after transceive command
+     */
+    mfrc522_drv_status_transceive_err = MAKE_STATUS(0x09, status_severity_critical),
+    /**<
+     * A mismatch between expected and actual RX data size
+     */
+    mfrc522_drv_status_transceive_rx_mism = MAKE_STATUS(0x0A, status_severity_critical),
+    /**<
+     * Unknown ATQA returned after REQA command
+     */
+    mfrc522_drv_status_picc_vrf_err = MAKE_STATUS(0x0B, status_severity_non_critical),
+    /**<
+     * Checksum error during anticollision
+     */
+    mfrc522_drv_status_anticoll_chksum_err = MAKE_STATUS(0x0C, status_severity_critical),
+    /**<
+     * Computed CRC does not match up with expected one
+     */
+    mfrc522_drv_status_crc_err = MAKE_STATUS(0x0D, status_severity_critical),
+    /**<
+     * Invalid state of the crypto unit
+     */
+    mfrc522_drv_status_crypto_err = MAKE_STATUS(0x0E, status_severity_critical),
+    /**<
+     * An error when halting a PICC
+     */
+    mfrc522_drv_status_halt_err = MAKE_STATUS(0x0F, status_severity_critical)
 } mfrc522_drv_status;
 
 /**

--- a/include/mfrc522_ll.h
+++ b/include/mfrc522_ll.h
@@ -2,6 +2,7 @@
 #define MFRC522_MFRC522_LL_H
 
 #include "type.h"
+#include "common.h"
 
 /* Ensure that either 'definition' or 'pointer' low-level communication method is used */
 #if MFRC522_LL_DEF
@@ -21,6 +22,18 @@ extern "C" {
 #endif
 
 /* ------------------------------------------------------------ */
+/* ---------------------------- Macros ------------------------ */
+/* ------------------------------------------------------------ */
+
+/**
+* Magic number regarded as an unique scope number that identifies this module
+*/
+#ifdef SCOPE_MAGIC
+#undef SCOPE_MAGIC
+#endif
+#define SCOPE_MAGIC 0xE0AA
+
+/* ------------------------------------------------------------ */
 /* -------------------------- Data types ---------------------- */
 /* ------------------------------------------------------------ */
 
@@ -29,9 +42,18 @@ extern "C" {
  */
 typedef enum mfrc522_ll_status_
 {
-    mfrc522_ll_status_ok = 0, /**< Success */
-    mfrc522_ll_status_send_err, /**< An error while sending data */
-    mfrc522_ll_status_recv_err /**< An error while receiving data */
+    /**<
+     * Success
+     */
+    mfrc522_ll_status_ok = MAKE_STATUS(0x00, status_severity_none),
+    /**<
+     * An error while sending data
+     */
+    mfrc522_ll_status_send_err = MAKE_STATUS(0x01, status_severity_fatal),
+    /**<
+     * An error while receiving data
+     */
+    mfrc522_ll_status_recv_err = MAKE_STATUS(0x02, status_severity_fatal)
 } mfrc522_ll_status;
 
 #if MFRC522_LL_PTR

--- a/ut/TestMfrc522DrvCommon.cpp
+++ b/ut/TestMfrc522DrvCommon.cpp
@@ -11,6 +11,36 @@ using namespace testing;
 /* ------------------------ Test cases ------------------------ */
 /* ------------------------------------------------------------ */
 
+TEST(TestMfrc522DrvCommon, StatusMacros__MiscCases)
+{
+
+#ifdef SCOPE_MAGIC
+#undef SCOPE_MAGIC
+#endif
+#define SCOPE_MAGIC 0xC0B0
+
+    /* Case 1 - fatal error */
+    u32 sc1 = MAKE_STATUS(0x99, status_severity_fatal);
+    ASSERT_EQ(SCOPE_MAGIC, ((sc1 >> STATUS_SCOPE_POS) & STATUS_SCOPE_MASK));
+    ASSERT_EQ(status_severity_fatal, ((sc1 >> STATUS_SEVERITY_POS) & STATUS_SEVERITY_MASK));
+    ASSERT_EQ(0x99, ((sc1 >> STATUS_SEQ_POS) & STATUS_SEQ_MASK));
+    ASSERT_TRUE(status_fatal(sc1));
+
+    /* Case 2 - critical error */
+    u32 sc2 = MAKE_STATUS(0xB0, status_severity_critical);
+    ASSERT_EQ(SCOPE_MAGIC, ((sc2 >> STATUS_SCOPE_POS) & STATUS_SCOPE_MASK));
+    ASSERT_EQ(status_severity_critical, ((sc2 >> STATUS_SEVERITY_POS) & STATUS_SEVERITY_MASK));
+    ASSERT_EQ(0xB0, ((sc2 >> STATUS_SEQ_POS) & STATUS_SEQ_MASK));
+    ASSERT_FALSE(status_fatal(sc2));
+
+    /* Case 3 - non-critical error */
+    u32 sc3 = MAKE_STATUS(0x07, status_severity_non_critical);
+    ASSERT_EQ(SCOPE_MAGIC, ((sc3 >> STATUS_SCOPE_POS) & STATUS_SCOPE_MASK));
+    ASSERT_EQ(status_severity_non_critical, ((sc3 >> STATUS_SEVERITY_POS) & STATUS_SEVERITY_MASK));
+    ASSERT_EQ(0x07, ((sc3 >> STATUS_SEQ_POS) & STATUS_SEQ_MASK));
+    ASSERT_FALSE(status_fatal(sc3));
+}
+
 TEST(TestMfrc522DrvCommon, mfrc522_drv_init__NullCases)
 {
     auto status = mfrc522_drv_init(nullptr);
@@ -74,10 +104,10 @@ TEST(TestMfrc522DrvCommon, mfrc522_drv_read__NullCases)
     u8 pl;
 
     auto status = mfrc522_drv_read(&conf, mfrc522_reg_fifo_data, nullptr);
-    ASSERT_EQ(mfrc522_ll_status_recv_err, status);
+    ASSERT_EQ(mfrc522_drv_status_nullptr, status);
 
     status = mfrc522_drv_read(nullptr, mfrc522_reg_fifo_data, &pl);
-    ASSERT_EQ(mfrc522_ll_status_recv_err, status);
+    ASSERT_EQ(mfrc522_drv_status_nullptr, status);
 }
 
 TEST(TestMfrc522DrvCommon, mfrc522_drv_fifo_store__ValidLowLevelCallIsMade)
@@ -300,7 +330,7 @@ TEST(TestMfrc522DrvCommon, mfrc522_drv_write_masked__MaskedWritePerformed)
         .WillOnce(Return(mfrc522_ll_status_ok));
 
     auto status = mfrc522_drv_write_masked(&conf, mfrc522_reg_gs_n, 13, msk, pos);
-    ASSERT_EQ(mfrc522_ll_status_ok, status);
+    ASSERT_EQ(mfrc522_drv_status_ok, status);
 }
 
 TEST(TestMfrc522DrvCommon, mfrc522_drv_read_masked__NullCases)
@@ -326,7 +356,7 @@ TEST(TestMfrc522DrvCommon, mfrc522_drv_read_masked__MaskedReadPerformed)
 
     /* Call FUT */
     auto status = mfrc522_drv_read_masked(&device, mfrc522_reg_fifo_data, &out, 0x0F, 4);
-    ASSERT_EQ(mfrc522_ll_status_ok, status);
+    ASSERT_EQ(mfrc522_drv_status_ok, status);
     ASSERT_EQ(0x0C, out);
 }
 

--- a/ut/TestMfrc522DrvLlPtr.cpp
+++ b/ut/TestMfrc522DrvLlPtr.cpp
@@ -62,7 +62,7 @@ TEST(TestMfrc522DrvLlPtr, mfrc522_drv_write__Success)
 
     u8 dummyByte = 0xAB;
     auto status = mfrc522_drv_write(&conf, mfrc522_reg_fifo_data, 1, &dummyByte);
-    ASSERT_EQ(mfrc522_ll_status_ok, status);
+    ASSERT_EQ(mfrc522_drv_status_ok, status);
 }
 
 TEST(TestMfrc522DrvLlPtr, mfrc522_drv_read__Success)
@@ -75,5 +75,5 @@ TEST(TestMfrc522DrvLlPtr, mfrc522_drv_read__Success)
 
     u8 buffer;
     auto status = mfrc522_drv_read(&conf, mfrc522_reg_fifo_data, &buffer);
-    ASSERT_EQ(mfrc522_ll_status_ok, status);
+    ASSERT_EQ(mfrc522_drv_status_ok, status);
 }


### PR DESCRIPTION
Divide status code into three parts:
 - scope (owner of the status)
 - severity level
 - unique status ID
 Add function to check if a status is fatal.
 Refactor unit tests after changes in the code.